### PR TITLE
specs: update control tweaks

### DIFF
--- a/manual_update_control.md
+++ b/manual_update_control.md
@@ -27,7 +27,7 @@ The new function `update_mode()` sets the default update mode for resources. It 
 * Pressing 'u' will start an update of the selected resource (including Tiltfile). (If there is a current update running, it will put it the selected resource at the front of the queue).
 * Pressing shift+'u' will do the same, unless the selected resource is using Live Update, in which case it will do an image update, not a live update.
 * Pressing 'y' will start an update of all dirty resources.
-* Pressing spacebar will toggle Pause. While Pause is on, Tilt will not queue builds automatically (including Tiltfile). At the moment the user turns off Pause, all resources with update_mode auto that have pending file edits will be enqueued.
+* Pressing spacebar will toggle Pause. While Pause is on, Tilt will not queue builds automatically (including Tiltfile), but it will still track file changes. At the moment the user turns off Pause, all resources with update_mode auto that have pending file edits will be enqueued.
 * The "Build" column will be renamed to "Update".
 * The Update column for a Resource will show:
   * If it's dirty. E.g., "*" if it's dirty. But also some indication that updates on each new update.. (e.g. two symbols and it switches between the two each time you save). This way the user knows Tilt is seeing the edits.

--- a/manual_update_control.md
+++ b/manual_update_control.md
@@ -23,9 +23,11 @@ The new function `update_mode()` sets the default update mode for resources. It 
 `k8s_resource` and `dc_resource` take an additional optional argument `update_mode` (default value: `UPDATE_AUTO`), which must be one of the above constants.
 
 ## UI Changes
+* On startup, resources with manual update_mode will be dirty and unbuilt (other than Tiltfile).
 * Pressing 'u' will start an update of the selected resource (including Tiltfile). (If there is a current update running, it will put it the selected resource at the front of the queue).
 * Pressing shift+'u' will do the same, unless the selected resource is using Live Update, in which case it will do an image update, not a live update.
-* Pressing spacebar will toggle Pause. While Pause is on, Tilt will not queue builds automatically. At the moment the user turns off Pause, all resources with pending file edits will be enqueued.
+* Pressing 'y' will start an update of all dirty resources.
+* Pressing spacebar will toggle Pause. While Pause is on, Tilt will not queue builds automatically (including Tiltfile). At the moment the user turns off Pause, all resources with update_mode auto that have pending file edits will be enqueued.
 * The "Build" column will be renamed to "Update".
 * The Update column for a Resource will show:
   * If it's dirty. E.g., "*" if it's dirty. But also some indication that updates on each new update.. (e.g. two symbols and it switches between the two each time you save). This way the user knows Tilt is seeing the edits.


### PR DESCRIPTION
A few items:
* We didn't specify whether automatically perform initial builds of manual resources.
* I feel like I'd want to hit a key to kick off a build all dirty resources far more often than I'd want to trigger a build on a specific resource.
* We weren't super explicit about whether unpausing means we also queue builds of manual resources. It does say "all resources", but it doesn't show awareness of the potential contentiousness of the interaction between that and manual resources. I think it makes sense to have unpause *not* do anything to manual resources, and basically just have unpause do whatever would have been done during the paused period. I could be convinced otherwise (and if unpause starts all dirty resources, then users could pause/unpause as a way to build all dirty resources...not sure if that's weird), but I'd like to be explicit about the interaction.