### PR TITLE
slim build: note about docker_build.only_rebuild_on vs live_update.fall_back_on

### DIFF
--- a/slim_build_context.md
+++ b/slim_build_context.md
@@ -132,6 +132,9 @@ Brief descriptions here, pros/cons in the next section.
       but maybe we can mostly mitigate that by advertising in our docs?). An
       simpler, less flexible alternative would be `includes=[...], excludes=[...]`.
       That might be flexible enough.
+   3. We should make it clear that we're ignoring these files from a _file watching
+      perspective_, but are _not_ excluding them from the build context (i.e. they
+      can still make it into the Docker image).
 
 4. ##### Allow `docker_build`'s context param to take either the string (directory) it currently does, or a new `BuildContext` type that specifies a directory and also watch/build rules.
 

--- a/slim_build_context.md
+++ b/slim_build_context.md
@@ -112,6 +112,8 @@ Brief descriptions here, pros/cons in the next section.
    3. Introduces a distinction between "files we include in the build" and
       "files we watch to trigger a build", making the user's required
       mental model a bit more complicated.
+   4. Potentially confusing when taken together with Live Update `fall_back_on` step;
+      we'll need to be extra clear about the interaction between these two concepts.
 
 3. ##### Add `docker_build` options `ignore` and/or `only`, which filter the build context.
 

--- a/slim_build_context.md
+++ b/slim_build_context.md
@@ -201,8 +201,8 @@ performing. How do we expect users to debug the image?
   doing a command-line docker build should be fine; it'll just produce an image
   with some more files than were there from the Tilt build. I think for someone
   to be bitten by this, they would need to make it through all four of: 1) using
-  this feature, 2) running into problems caused by misconfigured ignore patterns,
-  3) performing a docker build outside of Tilt to diagnose those problems, 4)
-  observing it working in the non-Tilt build but not the Tilt build, 5) failing
-  to blame Tilt after observing #4. I don't see a good way to mitigate this,
-  and it seems like an acceptable risk.
+  this feature, 2) running into problems caused by misconfigured ignore
+  patterns, 3) performing a docker build outside of Tilt to diagnose those
+  problems, 4) observing it working in the non-Tilt build but not the Tilt
+  build, 5) failing to blame Tilt after observing #4. I don't see a good way to
+  mitigate this, and it seems like an acceptable risk.


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch maiamcc/slim-build-liveupd-conflict:

32485115d50bd87952c416400548943a7221c8b6 (2019-05-13 13:29:56 -0400)
slim build: note about docker_build.only_rebuild_on vs live_update.fall_back_on

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics